### PR TITLE
Add a timeout to actually release the tag

### DIFF
--- a/.github/workflows/bump-version-tag.yml
+++ b/.github/workflows/bump-version-tag.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Sleep for 60s
+        uses: juliangruber/sleep-action@v2.0.0
+        with:
+          time: 60s
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
Increase timeout on the github action so that the tag can be created and released in the same run without it being event driven.

This can be fixed in the future, but I really couldn't be bothered to deal with that for now.