### PR TITLE
[BUG] Change the way go-releaser works

### DIFF
--- a/.github/workflows/bump-tag.yml
+++ b/.github/workflows/bump-tag.yml
@@ -1,0 +1,16 @@
+name: Bump tag
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -1,28 +1,24 @@
-name: Bump version
+name: goreleaser
+
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
 jobs:
-  build:
+  goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v4
-
-      - name: Bump version and push tag
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Sleep for 60s
-        uses: juliangruber/sleep-action@v2.0.0
-        with:
-          time: 60s
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
Change the way go releaser works to instead be event driven via a tag being released, and the tag gets released when a pr is pushed.