### PR TITLE
Add suspended accounts functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Usage:
 
 Flags:
 
+    -remove-suspended-accounts
+		Remove suspended accounts from the output (default false)
     -include-json
         Include the JSON representation of the AWS Organizations structure in the output (default true)
     -include-visual

--- a/generation/generation.go
+++ b/generation/generation.go
@@ -47,8 +47,5 @@ func GenerateStructure(ctx context.Context, orgClient *organizations.Client) (*O
 		return nil, err
 	}
 
-	// Remove suspended accounts
-	tree = tree.removeSuspendedAccounts()
-
 	return tree, nil
 }

--- a/generation/generation.go
+++ b/generation/generation.go
@@ -47,5 +47,8 @@ func GenerateStructure(ctx context.Context, orgClient *organizations.Client) (*O
 		return nil, err
 	}
 
+	// Remove suspended accounts
+	tree = tree.removeSuspendedAccounts()
+
 	return tree, nil
 }

--- a/generation/ou_struct.go
+++ b/generation/ou_struct.go
@@ -93,3 +93,20 @@ func (parent *OU) fillAccountsRecursive(ctx context.Context, api *organizations.
 
 	return parent, nil
 }
+
+// removeSuspendedAccounts removes all suspended accounts from the OU tree.
+func (parent *OU) removeSuspendedAccounts() *OU {
+	accounts := make([]types.Account, 0)
+	for _, account := range parent.Accounts {
+		if account.Status != types.AccountStatusSuspended {
+			accounts = append(accounts, account)
+		}
+	}
+	parent.Accounts = accounts
+
+	for i := range parent.Children {
+		parent.Children[i] = parent.Children[i].removeSuspendedAccounts()
+	}
+
+	return parent
+}

--- a/generation/ou_struct.go
+++ b/generation/ou_struct.go
@@ -95,7 +95,7 @@ func (parent *OU) fillAccountsRecursive(ctx context.Context, api *organizations.
 }
 
 // removeSuspendedAccounts removes all suspended accounts from the OU tree.
-func (parent *OU) removeSuspendedAccounts() *OU {
+func (parent *OU) RemoveSuspendedAccounts() *OU {
 	accounts := make([]types.Account, 0)
 	for _, account := range parent.Accounts {
 		if account.Status != types.AccountStatusSuspended {
@@ -105,7 +105,7 @@ func (parent *OU) removeSuspendedAccounts() *OU {
 	parent.Accounts = accounts
 
 	for i := range parent.Children {
-		parent.Children[i] = parent.Children[i].removeSuspendedAccounts()
+		parent.Children[i] = parent.Children[i].RemoveSuspendedAccounts()
 	}
 
 	return parent

--- a/generation/ou_struct_test.go
+++ b/generation/ou_struct_test.go
@@ -158,7 +158,7 @@ func TestRemoveSuspendedAccounts(t *testing.T) {
 	ou.Accounts = accounts
 
 	// Remove the suspended accounts.
-	ou = ou.removeSuspendedAccounts()
+	ou = ou.RemoveSuspendedAccounts()
 
 	// Check that the correct accounts were removed.
 	require.Len(t, ou.Accounts, 1, "removeSuspendedAccounts did not remove the correct accounts")

--- a/generation/ou_struct_test.go
+++ b/generation/ou_struct_test.go
@@ -133,3 +133,34 @@ func TestOuFillOuTree(t *testing.T) {
 	require.Equal(t, "ou-5678", ou.Children[0].Id, "OU children was not set correctly")
 	require.Equal(t, "TestChildOU", ou.Children[0].Name, "OU children was not set correctly")
 }
+
+// TestRemoveSuspendedAccounts tests the removeSuspendedAccounts method of the OU struct.
+func TestRemoveSuspendedAccounts(t *testing.T) {
+	// Create an OU struct.
+	ou := &OU{
+		Id:   "ou-1234",
+		Name: "TestOU",
+	}
+
+	// Create a list of accounts.
+	accounts := []types.Account{
+		{
+			Id:     aws.String("123456789"),
+			Status: types.AccountStatusActive,
+		},
+		{
+			Id:     aws.String("987654321"),
+			Status: types.AccountStatusSuspended,
+		},
+	}
+
+	// Add the accounts to the OU.
+	ou.Accounts = accounts
+
+	// Remove the suspended accounts.
+	ou = ou.removeSuspendedAccounts()
+
+	// Check that the correct accounts were removed.
+	require.Len(t, ou.Accounts, 1, "removeSuspendedAccounts did not remove the correct accounts")
+	require.Equal(t, "123456789", *ou.Accounts[0].Id, "removeSuspendedAccounts did not remove the correct accounts")
+}

--- a/main.go
+++ b/main.go
@@ -18,12 +18,14 @@
 //
 // Flags:
 //
-//	-include-json
-//	      Include the JSON representation of the AWS Organizations structure in the output (default true)
-//	-include-visual
-//	      Include the visual representation of the AWS Organizations structure in the output (default true)
-//	-o string
-//	      The output file for the JSON representation of the AWS Organizations structure (default "output.json")
+//	    -remove-suspended-accounts
+//		      Remove suspended accounts from the output (default false)
+//		-include-json
+//		      Include the JSON representation of the AWS Organizations structure in the output (default true)
+//		-include-visual
+//		      Include the visual representation of the AWS Organizations structure in the output (default true)
+//		-o string
+//		      The output file for the JSON representation of the AWS Organizations structure (default "output.json")
 package main
 
 import (
@@ -96,6 +98,7 @@ func checkPermissions() (context.Context, *organizations.Client, error) {
 // is executed and is used to call the main logic of the application.
 func main() {
 	// STAGE 1: Sort out the input flags
+	removeSuspendedAccountsPtr := flag.Bool("remove-suspended-accounts", false, "Remove suspended accounts from the output")
 	jsonPtr := flag.Bool("include-json", true, "Include the JSON representation of the AWS Organizations structure in the output")
 	visualPtr := flag.Bool("include-visual", true, "Include the visual representation of the AWS Organizations structure in the output")
 	outputPtr := flag.String("o", "output.json", "The output file for the JSON representation of the AWS Organizations structure")
@@ -114,12 +117,14 @@ func main() {
 
 	// STAGE 3: Run the main logic of the application to generate the data
 	// structure
-	context.Background()
 	tree, err := generation.GenerateStructure(ctx, cfg)
 	if err != nil {
 		fmt.Println("Error generating structure")
 		logs.Println(err)
 		return
+	}
+	if *removeSuspendedAccountsPtr {
+		tree = tree.RemoveSuspendedAccounts()
 	}
 
 	// STAGE 4: Determine the output format and output the data structure


### PR DESCRIPTION
This pr adds a new flag:
```
    -remove-suspended-accounts
		Remove suspended accounts from the output (default false)
```

This flag allows the user to have suspended accounts removed from the output automagically. This allows the user to not have to include logic on their end to try and sort the account states.

As the default is false, this doesn't do anything to existing usage of this tool, but if you add the flag on this latest version it will potentially produce a different output.